### PR TITLE
Remove `RETURNING` sql clause, with other refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +112,33 @@ dependencies = [
  "num-traits",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -341,6 +362,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -663,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +967,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -1225,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1447,20 +1509,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
 name = "trakt-tv-updater"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
+ "color-eyre",
  "crossbeam",
  "crossterm",
  "csv",
  "diesel",
  "diesel-derive-enum",
  "dotenvy",
+ "eyre",
  "futures",
  "governor",
  "log",
@@ -1533,6 +1618,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.71"
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
+color-eyre = "0.6"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 crossterm = "0.26.1"
 csv = "1.2.2"
 diesel = { version = "2.1.0", features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"] }
 diesel-derive-enum = { version = "2.1.0", features = ["sqlite"] }
 dotenvy = "0.15.7"
+eyre = "0.6"
 futures = "0.3.28"
 governor = "0.5.1"
 log = "0.4.19"

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -1,5 +1,3 @@
-use std::error;
-
 use crate::{
     models::{TraktShow, UserStatus},
     trakt::{t_api, t_db},
@@ -9,9 +7,6 @@ use log::*;
 use ratatui::widgets::{ScrollbarState, TableState};
 use reqwest::Client;
 use tui_input::Input;
-
-/// Application result type.
-pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 /// Different modes for the app.
 #[derive(PartialEq, Eq, Debug, Default)]

--- a/src/interface/event.rs
+++ b/src/interface/event.rs
@@ -1,4 +1,3 @@
-use crate::interface::app::AppResult;
 use crossterm::event::{self, Event as CrosstermEvent, KeyEvent, MouseEvent};
 use std::sync::mpsc;
 use std::thread;
@@ -71,7 +70,7 @@ impl EventHandler {
     ///
     /// This function will always block the current thread if
     /// there is no data available and it's possible for more data to be sent.
-    pub fn next(&self) -> AppResult<Event> {
+    pub fn next(&self) -> eyre::Result<Event> {
         Ok(self.receiver.recv()?)
     }
 }

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -1,11 +1,11 @@
-use crate::interface::app::{App, AppMode, AppResult};
+use crate::interface::app::{App, AppMode};
 use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::event::{MouseEvent, MouseEventKind};
 
 use tui_input::backend::crossterm::EventHandler;
 
 /// Handles the key events and updates the state of [`App`].
-pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
+pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Result<()> {
     // Exit application from any mode on `Ctrl-C`
     match key_event.code {
         KeyCode::Char('c') | KeyCode::Char('C') => {
@@ -90,7 +90,7 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<
 }
 
 // handle mouse events as well
-pub fn handle_mouse_events(mouse_event: MouseEvent, app: &mut App) -> AppResult<()> {
+pub fn handle_mouse_events(mouse_event: MouseEvent, app: &mut App) -> eyre::Result<()> {
     match app.mode {
         AppMode::MainView => match mouse_event.kind {
             MouseEventKind::ScrollDown => {

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -55,12 +55,12 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Resu
                 app.mode = AppMode::Querying;
             }
             // cycle through watch status for a show
-            KeyCode::Char(' ') => app.toggle_watch_status(),
+            KeyCode::Char(' ') => app.toggle_watch_status()?,
 
             // open up tv show details view
             KeyCode::Char('l') | KeyCode::Right => {
                 // app will only change its UI if a show is selected.
-                app.enter_show_details().await;
+                app.enter_show_details().await?;
             }
 
             _ => {}

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -14,7 +14,7 @@ mod tui;
 mod handler;
 
 use crate::interface::{
-    app::{App, AppResult},
+    app::App,
     event::{Event, EventHandler},
     handler::{handle_key_events, handle_mouse_events},
     tui::Tui,
@@ -23,7 +23,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io;
 
-pub async fn run() -> AppResult<()> {
+pub async fn run() -> eyre::Result<()> {
     // Create an application.
     let mut app = App::new();
 

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -25,7 +25,7 @@ use std::io;
 
 pub async fn run() -> eyre::Result<()> {
     // Create an application.
-    let mut app = App::new()?;
+    let app = App::new()?;
 
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
@@ -35,6 +35,21 @@ pub async fn run() -> eyre::Result<()> {
     tui.init()?;
 
     // Start the main loop.
+    let res = main_loop(app, &mut tui).await;
+
+    if let Err(e) = &res {
+        log::error!("App quit unexpectedly: {e:?}");
+    }
+
+    // Exit the user interface.
+    tui.exit()?;
+    res
+}
+
+async fn main_loop<B: ratatui::backend::Backend>(
+    mut app: App,
+    tui: &mut Tui<B>,
+) -> eyre::Result<()> {
     while app.running {
         // Render the user interface.
         tui.draw(&mut app)?;
@@ -46,8 +61,5 @@ pub async fn run() -> eyre::Result<()> {
             Event::Resize(_, _) => {}
         }
     }
-
-    // Exit the user interface.
-    tui.exit()?;
     Ok(())
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -25,7 +25,7 @@ use std::io;
 
 pub async fn run() -> eyre::Result<()> {
     // Create an application.
-    let mut app = App::new();
+    let mut app = App::new()?;
 
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
@@ -40,7 +40,7 @@ pub async fn run() -> eyre::Result<()> {
         tui.draw(&mut app)?;
         // Handle events.
         match tui.events.next()? {
-            Event::Tick => app.tick(),
+            Event::Tick => app.tick()?,
             Event::Key(key_event) => handle_key_events(key_event, &mut app).await?,
             Event::Mouse(mouse_event) => handle_mouse_events(mouse_event, &mut app)?,
             Event::Resize(_, _) => {}

--- a/src/interface/tui.rs
+++ b/src/interface/tui.rs
@@ -1,8 +1,4 @@
-use crate::interface::{
-    app::{App, AppResult},
-    event::EventHandler,
-    ui,
-};
+use crate::interface::{app::App, event::EventHandler, ui};
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::backend::Backend;
@@ -30,7 +26,7 @@ impl<B: Backend> Tui<B> {
     /// Initializes the terminal interface.
     ///
     /// It enables the raw mode and sets terminal properties.
-    pub fn init(&mut self) -> AppResult<()> {
+    pub fn init(&mut self) -> eyre::Result<()> {
         terminal::enable_raw_mode()?;
         crossterm::execute!(io::stderr(), EnterAlternateScreen, EnableMouseCapture)?;
         self.terminal.hide_cursor()?;
@@ -42,7 +38,7 @@ impl<B: Backend> Tui<B> {
     ///
     /// [`Draw`]: tui::Terminal::draw
     /// [`rendering`]: crate::ui:render
-    pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
+    pub fn draw(&mut self, app: &mut App) -> eyre::Result<()> {
         self.terminal.draw(|frame| ui::render(app, frame))?;
         Ok(())
     }
@@ -50,7 +46,7 @@ impl<B: Backend> Tui<B> {
     /// Exits the terminal interface.
     ///
     /// It disables the raw mode and reverts back the terminal properties.
-    pub fn exit(&mut self) -> AppResult<()> {
+    pub fn exit(&mut self) -> eyre::Result<()> {
         terminal::disable_raw_mode()?;
         crossterm::execute!(io::stderr(), LeaveAlternateScreen, DisableMouseCapture)?;
         self.terminal.show_cursor()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,18 @@ use simplelog::*;
 use std::fs::File;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+
     // init logging
     WriteLogger::init(
         LevelFilter::Debug,
-        Config::default(),
+        ConfigBuilder::default()
+            .set_location_level(simplelog::LevelFilter::Info)
+            .build(),
         File::create("trakt_updater.log").unwrap(),
     )
     .unwrap();
 
-    let _ = interface::run().await;
+    interface::run().await
 }

--- a/src/trakt/t_api.rs
+++ b/src/trakt/t_api.rs
@@ -74,7 +74,7 @@ pub struct ApiSeasonDetails {
 
 /// Creates a single HTTP client to use for trakt.tv requests
 pub fn establish_http_client() -> Client {
-    // TODO: anyhow/error handle this (as part of app startup?)
+    // TODO: eyre/error handle this (as part of app startup?)
     dotenv().ok();
 
     let mut headers = header::HeaderMap::new();
@@ -112,7 +112,7 @@ pub fn establish_http_client() -> Client {
         .unwrap()
 }
 
-async fn do_req(client: &reqwest::Client, endpoint: &str) -> anyhow::Result<String> {
+async fn do_req(client: &reqwest::Client, endpoint: &str) -> eyre::Result<String> {
     let search_url = format!("{}/{}", TRAKT_URL, endpoint);
 
     let response = client.get(search_url).send().await?;
@@ -125,7 +125,7 @@ async fn do_req(client: &reqwest::Client, endpoint: &str) -> anyhow::Result<Stri
 async fn query_show_info(
     client: &reqwest::Client,
     imdb_id: &String,
-) -> anyhow::Result<ApiShowDetails> {
+) -> eyre::Result<ApiShowDetails> {
     let text = do_req(client, &format!("shows/{}?extended=full", imdb_id)).await?;
     Ok(serde_json::from_str::<ApiShowDetails>(&text)?)
 }
@@ -133,7 +133,7 @@ async fn query_show_info(
 async fn query_season_info(
     client: &reqwest::Client,
     imdb_id: &String,
-) -> anyhow::Result<Vec<ApiSeasonDetails>> {
+) -> eyre::Result<Vec<ApiSeasonDetails>> {
     let text = do_req(client, &format!("shows/{}/seasons?extended=full", imdb_id)).await?;
     Ok(serde_json::from_str::<Vec<ApiSeasonDetails>>(&text)?)
 }
@@ -143,7 +143,7 @@ async fn query_season_info(
 pub async fn query_detailed(
     client: &reqwest::Client,
     imdb_id: &String,
-) -> anyhow::Result<(ApiShowDetails, Vec<ApiSeasonDetails>)> {
+) -> eyre::Result<(ApiShowDetails, Vec<ApiSeasonDetails>)> {
     let show_info = query_show_info(client, &imdb_id).await?;
     let season_info = query_season_info(client, &imdb_id).await?;
     Ok((show_info, season_info))

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -52,7 +52,6 @@ pub fn update_show(show: &TraktShow) -> eyre::Result<()> {
 
     match diesel::insert_into(trakt_shows)
         .values(show)
-        .returning(TraktShow::as_returning())
         .on_conflict(imdb_id)
         .do_update()
         .set(user_status.eq(&show.user_status))
@@ -78,7 +77,6 @@ pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) -
     for row in rows {
         match diesel::insert_into(trakt_shows)
             .values(row)
-            .returning(TraktShow::as_returning())
             .on_conflict(imdb_id)
             .do_update()
             // update the values that might be updated in a new data dump

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -68,7 +68,7 @@ pub fn update_show(show: &TraktShow) {
 }
 
 /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) {
+pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) -> eyre::Result<()> {
     info!("Filling db...");
 
     use self::trakt_shows::dsl::*;
@@ -94,10 +94,12 @@ pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) {
             Err(err) => {
                 // TODO: if this errs, should bubble up and quit app?
                 info!("Failed db insert: {}", err);
-                panic!();
+                return Err(eyre::eyre!(err));
             }
         }
     }
 
     info!("Inserted/Updated {} rows.", rows.len());
+
+    Ok(())
 }

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -45,7 +45,7 @@ pub fn load_filtered_shows(ctx: &mut SqliteConnection) -> Vec<TraktShow> {
 }
 
 /// update the status of a show **in the DB**
-pub fn update_show(show: &TraktShow) {
+pub fn update_show(show: &TraktShow) -> eyre::Result<()> {
     use self::trakt_shows::dsl::*;
 
     let mut ctx = establish_ctx();
@@ -60,9 +60,11 @@ pub fn update_show(show: &TraktShow) {
     {
         Ok(_) => {
             info!("Updated row: {}", &show.imdb_id);
+            Ok(())
         }
         Err(err) => {
             info!("panik on update: {}", err);
+            Err(eyre::eyre!(err))
         }
     }
 }


### PR DESCRIPTION
* Use eyre for error propagation. It is similar to anyhow, but has better error messages and stack traces
* Make more functions bubble up errors instead of panicking
* Make `DataManager` type which manages the thread's channels itself
