### PR TITLE
Introduce `Database` wrapper type, and handle synchronization internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,64 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,15 +756,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1442,9 +1375,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -1539,7 +1470,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "color-eyre",
- "crossbeam",
  "crossterm",
  "csv",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
 color-eyre = "0.6"
-crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 crossterm = "0.26.1"
 csv = "1.2.2"
 diesel = { version = "2.1.0", features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"] }
@@ -25,7 +24,7 @@ reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"
 simplelog = "0.12.1"
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "sync"] }
 tui-input = "0.7.1"
 
 [dependencies.ratatui]

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -3,7 +3,6 @@ use crate::{
     sources::DataManager,
     trakt::{t_api, t_db},
 };
-use crossbeam::channel::{unbounded, Receiver, SendError, Sender};
 use log::*;
 use ratatui::widgets::{ScrollbarState, TableState};
 use reqwest::Client;
@@ -20,6 +19,7 @@ pub enum AppMode {
     /// somewhat of a todo state, i haven't impl'd searching yet
     Querying,
     /// Show keybindings
+    #[allow(dead_code)]
     HelpWindow,
     /// Detailed view of specific season
     SeasonView,

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -164,7 +164,7 @@ impl App {
             };
 
             // update db
-            t_db::update_show(show)?;
+            t_db::Database::connect()?.update_show(show)?;
         }
 
         Ok(())

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -91,7 +91,7 @@ impl App {
     pub fn tick(&mut self) -> eyre::Result<()> {
         // WIP implementation of query from our data rows
         // (right now, just pull everything on boot)
-        if self.shows.len() == 0 {
+        if self.shows.is_empty() {
             let items = self
                 .data_manager
                 .query(String::from("spurious"))
@@ -179,7 +179,7 @@ impl App {
                     // t_db::update_show_info(&ctx ...);
 
                     self.show_view.show_details = Some(show_details);
-                    if season_details.len() > 0 {
+                    if !season_details.is_empty() {
                         self.show_view.season_table_state.select(Some(0));
                     }
                     self.show_view.seasons = season_details;

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -55,7 +55,7 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Resu
                 app.mode = AppMode::Querying;
             }
             // cycle through watch status for a show
-            KeyCode::Char(' ') => app.toggle_watch_status()?,
+            KeyCode::Char(' ') => app.toggle_watch_status().await?,
 
             // open up tv show details view
             KeyCode::Char('l') | KeyCode::Right => {

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -91,6 +91,7 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Resu
 
 // handle mouse events as well
 pub fn handle_mouse_events(mouse_event: MouseEvent, app: &mut App) -> eyre::Result<()> {
+    #[allow(clippy::single_match)]
     match app.mode {
         AppMode::MainView => match mouse_event.kind {
             MouseEventKind::ScrollDown => {

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -25,7 +25,7 @@ use std::io;
 
 pub async fn run() -> eyre::Result<()> {
     // Create an application.
-    let app = App::new()?;
+    let app = App::new().await?;
 
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
@@ -55,7 +55,7 @@ async fn main_loop<B: ratatui::backend::Backend>(
         tui.draw(&mut app)?;
         // Handle events.
         match tui.events.next()? {
-            Event::Tick => app.tick()?,
+            Event::Tick => app.tick().await?,
             Event::Key(key_event) => handle_key_events(key_event, &mut app).await?,
             Event::Mouse(mouse_event) => handle_mouse_events(mouse_event, &mut app)?,
             Event::Resize(_, _) => {}

--- a/src/interface/ui.rs
+++ b/src/interface/ui.rs
@@ -125,7 +125,7 @@ fn render_main_view<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
     render_shows_table(app, frame, outer[1]);
 }
 
-fn initalize_app<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+fn initalize_app<B: Backend>(_app: &mut App, frame: &mut Frame<'_, B>) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(

--- a/src/sources/imdb_reader.rs
+++ b/src/sources/imdb_reader.rs
@@ -48,10 +48,7 @@ fn load_show_vec_from_source(dump_file_name: &str) -> Vec<TraktShow> {
             trakt_id: None,
             primary_title: show.primary_title.unwrap(),
             original_title: show.original_title.unwrap(),
-            release_year: match show.start_year {
-                Some(expr) => Some(expr as i32),
-                None => None,
-            },
+            release_year: show.start_year.map(|y| y as i32),
             no_seasons: None,
             no_episodes: None,
             country: None,

--- a/src/sources/imdb_reader.rs
+++ b/src/sources/imdb_reader.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::TraktShow;
 
 /// currently unimpl'd: will be used to download IMDB dataset on init
-pub fn download_source() {
+pub fn _download_source() {
     unimplemented!();
 }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -3,7 +3,7 @@ use diesel::SqliteConnection;
 use log::*;
 
 use crate::models::TraktShow;
-use crate::trakt::{t_api, t_db};
+use crate::trakt::t_db;
 
 pub mod imdb_reader;
 
@@ -40,6 +40,7 @@ fn load_combined_data_sources(ctx: &mut SqliteConnection) -> eyre::Result<Vec<Tr
 
 #[derive(Debug)]
 pub struct DataManager {
+    #[allow(dead_code)]
     handle: std::thread::JoinHandle<()>,
     query_sender: Sender<String>,
     result_receiver: Receiver<Vec<TraktShow>>,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,5 +1,3 @@
-use crossbeam::channel::{Receiver, RecvError, Sender};
-use diesel::SqliteConnection;
 use log::*;
 
 use crate::models::TraktShow;
@@ -20,66 +18,39 @@ pub mod imdb_reader;
 /// Load all shows from imdb data dump and db.
 /// TODO: for now, assume that first startup fills all rows into db.
 /// Eventually, we may have to update this to update db on startup from a new data dump.
-fn load_combined_data_sources(db: &mut t_db::Database) -> eyre::Result<Vec<TraktShow>> {
+async fn load_combined_data_sources(db: &mut t_db::Database) -> eyre::Result<Vec<TraktShow>> {
     // load all shows, and fill db if db is empty
     // let items = imdb_reader::load_show_vec();
 
-    let row_count = db.count_shows();
+    let row_count = db.count_shows().await;
     info!("row count: {}", row_count);
 
     if row_count < 100 {
         // if we dont have many rows in db (clean env or devel), load from imdb data
         let items = imdb_reader::load_show_vec();
         // TODO: put this on a thread, once i figure out borrowing?
-        db.prefill_from_imdb(&items).map(|()| items)
+        db.prefill_from_imdb(items.clone()).await.map(|()| items)
     } else {
         // query everything from db
-        Ok(db.filtered_shows())
+        Ok(db.filtered_shows().await)
     }
 }
 
 #[derive(Debug)]
 pub struct DataManager {
-    #[allow(dead_code)]
-    handle: std::thread::JoinHandle<()>,
-    query_sender: Sender<String>,
-    result_receiver: Receiver<Vec<TraktShow>>,
+    items: Vec<TraktShow>,
 }
 
 impl DataManager {
-    pub fn init() -> eyre::Result<DataManager> {
-        let mut db = t_db::Database::connect()?;
-        let items = load_combined_data_sources(&mut db)?;
-        let (query_sender, query_receiver) = crossbeam::channel::unbounded();
-        let (result_sender, result_receiver) = crossbeam::channel::unbounded();
+    pub async fn init() -> eyre::Result<DataManager> {
+        let mut db = t_db::Database::connect().await?;
+        let items = load_combined_data_sources(&mut db).await?;
 
-        let handle = std::thread::spawn(move || {
-            loop {
-                match query_receiver.recv() {
-                    Ok(_query) => {
-                        // TODO: can i pass this as a ref instead of cloning?
-                        // would that even be better?
-                        result_sender.send(items.clone()).unwrap();
-                    }
-                    // happens when channel is empty + becomes disconnected
-                    // i think this only happens when user shuts down app
-                    Err(RecvError) => {}
-                }
-            }
-        });
-
-        Ok(DataManager {
-            handle,
-            query_sender,
-            result_receiver,
-        })
+        Ok(DataManager { items })
     }
 
     /// Returns `None` if the servicing thread has died.
-    pub fn query(&self, q: String) -> Option<Vec<TraktShow>> {
-        match (self.query_sender.send(q), self.result_receiver.recv()) {
-            (Ok(()), Ok(r)) => Some(r),
-            _ => None,
-        }
+    pub async fn query(&self, _q: String) -> Option<Vec<TraktShow>> {
+        Some(self.items.clone())
     }
 }

--- a/src/trakt/t_api.rs
+++ b/src/trakt/t_api.rs
@@ -149,7 +149,8 @@ pub async fn query_detailed(
     Ok((show_info, season_info))
 }
 
-pub async fn fill_trakt_db_from_imdb(ctx: &mut SqliteConnection, imdb_id: u32) {
+#[allow(unused)]
+pub async fn fill_trakt_db_from_imdb(_ctx: &mut SqliteConnection, _imdb_id: u32) {
     let lim = RateLimiter::direct(Quota::per_second(nonzero!(RATE_LIMIT)));
 
     // until_ready should block until the limiter is ready to submit another job, right?
@@ -180,6 +181,7 @@ pub async fn fill_trakt_db_from_imdb(ctx: &mut SqliteConnection, imdb_id: u32) {
     unimplemented!();
 }
 
+#[cfg(tests)]
 mod tests {
     #[test]
     fn check_rate_limit() {

--- a/src/trakt/t_api.rs
+++ b/src/trakt/t_api.rs
@@ -144,8 +144,8 @@ pub async fn query_detailed(
     client: &reqwest::Client,
     imdb_id: &String,
 ) -> eyre::Result<(ApiShowDetails, Vec<ApiSeasonDetails>)> {
-    let show_info = query_show_info(client, &imdb_id).await?;
-    let season_info = query_season_info(client, &imdb_id).await?;
+    let show_info = query_show_info(client, imdb_id).await?;
+    let season_info = query_season_info(client, imdb_id).await?;
     Ok((show_info, season_info))
 }
 
@@ -159,17 +159,14 @@ pub async fn fill_trakt_db_from_imdb(_ctx: &mut SqliteConnection, _imdb_id: u32)
     //
     // keeping this around so i remember how to use it
     loop {
-        match lim.check() {
-            Ok(_) => {
-                // for api_show in query_trakt_api(&client, tmdb_id).await {
-                //     println!("querying...");
-                //     // shows.push(api_show)
-                //     write_trakt_db(ctx, api_show);
-                // }
+        if lim.check().is_ok() {
+            // for api_show in query_trakt_api(&client, tmdb_id).await {
+            //     println!("querying...");
+            //     // shows.push(api_show)
+            //     write_trakt_db(ctx, api_show);
+            // }
 
-                break;
-            }
-            Err(_) => {}
+            break;
         }
 
         thread::sleep(TIME_STEP);

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -5,60 +5,112 @@ use chrono::prelude::*;
 use eyre::Context;
 use log::*;
 use std::env;
+use std::sync::Arc;
 
 use diesel::prelude::*;
 use dotenvy::dotenv;
 
+/// A handle to the database of show data. Async methods for queries and updates
+/// are provided, synchronization happens internally.
+#[derive(Clone)]
 pub struct Database {
-    conn: SqliteConnection,
+    conn: Conn,
+}
+
+type Conn = Arc<tokio::sync::Mutex<SqliteConnection>>;
+
+impl std::fmt::Debug for Database {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Database { ... }")
+    }
 }
 
 impl Database {
-    pub fn connect() -> eyre::Result<Database> {
+    pub fn connect_sync() -> eyre::Result<Database> {
         dotenv().ok();
 
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
         Ok(Database {
-            conn: SqliteConnection::establish(&database_url)?,
+            conn: Arc::new(tokio::sync::Mutex::new(SqliteConnection::establish(
+                &database_url,
+            )?)),
         })
+    }
+
+    pub async fn connect() -> eyre::Result<Database> {
+        tokio::task::spawn_blocking(Self::connect_sync)
+            .await
+            .unwrap()
     }
 
     /// count the rows in the db
     /// (this should be fast - am i doing this inefficiently?)
-    pub fn count_shows(&mut self) -> usize {
+    pub async fn count_shows(&self) -> usize {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::count_shows_impl(conn))
+            .await
+            .unwrap()
+    }
+
+    /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
+    pub async fn filtered_shows(&self) -> Vec<TraktShow> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::filtered_shows_impl(conn))
+            .await
+            .unwrap()
+    }
+
+    /// update the status of a show **in the DB**
+    pub async fn update_show(&self, show: TraktShow) -> eyre::Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::update_show_impl(conn, &show))
+            .await
+            .unwrap()
+    }
+
+    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
+    pub async fn prefill_from_imdb(&self, rows: Vec<TraktShow>) -> eyre::Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::prefill_from_imdb_impl(conn, &rows))
+            .await
+            .unwrap()
+    }
+
+    fn count_shows_impl(conn: Conn) -> usize {
         use self::trakt_shows::dsl::*;
 
+        let mut conn = conn.blocking_lock();
         let rows = trakt_shows
             .select(TraktShow::as_select())
-            .load_iter(&mut self.conn)
+            .load_iter(&mut *conn)
             .unwrap();
 
         rows.into_iter().count()
     }
 
-    /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
-    pub fn filtered_shows(&mut self) -> Vec<TraktShow> {
+    fn filtered_shows_impl(conn: Conn) -> Vec<TraktShow> {
         let cap_year = Utc::now().year() + 1;
 
+        let mut conn = conn.blocking_lock();
         trakt_shows::table
             .order_by(trakt_shows::release_year)
             .filter(trakt_shows::release_year.le(cap_year))
             .filter(trakt_shows::user_status.ne(UserStatus::Unwatched))
             .select(TraktShow::as_returning())
-            .load(&mut self.conn)
+            .load(&mut *conn)
             .unwrap()
     }
 
-    /// update the status of a show **in the DB**
-    pub fn update_show(&mut self, show: &TraktShow) -> eyre::Result<()> {
+    fn update_show_impl(conn: Conn, show: &TraktShow) -> eyre::Result<()> {
         use self::trakt_shows::dsl::*;
 
+        let mut conn = conn.blocking_lock();
         diesel::insert_into(trakt_shows)
             .values(show)
             .on_conflict(imdb_id)
             .do_update()
             .set(user_status.eq(&show.user_status))
-            .execute(&mut self.conn)
+            .execute(&mut *conn)
             .map(|_| ())
             .wrap_err("could not update show in db")?;
 
@@ -66,8 +118,7 @@ impl Database {
         Ok(())
     }
 
-    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-    pub fn prefill_from_imdb(&mut self, rows: &Vec<TraktShow>) -> eyre::Result<()> {
+    fn prefill_from_imdb_impl(conn: Conn, rows: &Vec<TraktShow>) -> eyre::Result<()> {
         info!("Filling db...");
 
         use self::trakt_shows::dsl::*;
@@ -83,7 +134,7 @@ impl Database {
                     no_seasons.eq(&row.no_seasons),
                     no_episodes.eq(&row.no_episodes),
                 ))
-                .execute(&mut self.conn)
+                .execute(&mut *conn.blocking_lock())
                 .map(|_| ())
                 .wrap_err("could not insert show")?;
 

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -2,104 +2,96 @@ use crate::models::{TraktShow, UserStatus};
 use crate::schema::trakt_shows;
 
 use chrono::prelude::*;
+use eyre::Context;
 use log::*;
 use std::env;
 
 use diesel::prelude::*;
 use dotenvy::dotenv;
 
-pub fn establish_ctx() -> SqliteConnection {
-    dotenv().ok();
-
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
-    SqliteConnection::establish(&database_url).unwrap_or_else(|err| {
-        info!("{}", err);
-        panic!();
-    })
+pub struct Database {
+    conn: SqliteConnection,
 }
 
-/// count the rows in the db
-/// (this should be fast - am i doing this inefficiently?)
-pub fn count_trakt_db(ctx: &mut SqliteConnection) -> usize {
-    use self::trakt_shows::dsl::*;
+impl Database {
+    pub fn connect() -> eyre::Result<Database> {
+        dotenv().ok();
 
-    let rows = trakt_shows
-        .select(TraktShow::as_select())
-        .load_iter(ctx)
-        .unwrap();
-
-    rows.into_iter().count()
-}
-
-/// Return all rows in the db that are not marked as unwatched, and don't have release in the future
-pub fn load_filtered_shows(ctx: &mut SqliteConnection) -> Vec<TraktShow> {
-    let cap_year = Utc::now().year() + 1;
-
-    trakt_shows::table
-        .order_by(trakt_shows::release_year)
-        .filter(trakt_shows::release_year.le(cap_year))
-        .filter(trakt_shows::user_status.ne(UserStatus::Unwatched))
-        .select(TraktShow::as_returning())
-        .load(ctx)
-        .unwrap()
-}
-
-/// update the status of a show **in the DB**
-pub fn update_show(show: &TraktShow) -> eyre::Result<()> {
-    use self::trakt_shows::dsl::*;
-
-    let mut ctx = establish_ctx();
-
-    match diesel::insert_into(trakt_shows)
-        .values(show)
-        .on_conflict(imdb_id)
-        .do_update()
-        .set(user_status.eq(&show.user_status))
-        .execute(&mut ctx)
-    {
-        Ok(_) => {
-            info!("Updated row: {}", &show.imdb_id);
-            Ok(())
-        }
-        Err(err) => {
-            info!("panik on update: {}", err);
-            Err(eyre::eyre!(err))
-        }
+        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
+        Ok(Database {
+            conn: SqliteConnection::establish(&database_url)?,
+        })
     }
-}
 
-/// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) -> eyre::Result<()> {
-    info!("Filling db...");
+    /// count the rows in the db
+    /// (this should be fast - am i doing this inefficiently?)
+    pub fn count_shows(&mut self) -> usize {
+        use self::trakt_shows::dsl::*;
 
-    use self::trakt_shows::dsl::*;
+        let rows = trakt_shows
+            .select(TraktShow::as_select())
+            .load_iter(&mut self.conn)
+            .unwrap();
 
-    for row in rows {
-        match diesel::insert_into(trakt_shows)
-            .values(row)
+        rows.into_iter().count()
+    }
+
+    /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
+    pub fn filtered_shows(&mut self) -> Vec<TraktShow> {
+        let cap_year = Utc::now().year() + 1;
+
+        trakt_shows::table
+            .order_by(trakt_shows::release_year)
+            .filter(trakt_shows::release_year.le(cap_year))
+            .filter(trakt_shows::user_status.ne(UserStatus::Unwatched))
+            .select(TraktShow::as_returning())
+            .load(&mut self.conn)
+            .unwrap()
+    }
+
+    /// update the status of a show **in the DB**
+    pub fn update_show(&mut self, show: &TraktShow) -> eyre::Result<()> {
+        use self::trakt_shows::dsl::*;
+
+        diesel::insert_into(trakt_shows)
+            .values(show)
             .on_conflict(imdb_id)
             .do_update()
-            // update the values that might be updated in a new data dump
-            .set((
-                release_year.eq(&row.release_year),
-                no_seasons.eq(&row.no_seasons),
-                no_episodes.eq(&row.no_episodes),
-            ))
-            .execute(ctx)
-        {
-            Ok(_c) => {
-                // can i count only which rows were updated?
-                info!("Inserted row: {}", &row.imdb_id);
-            }
-            Err(err) => {
-                // TODO: if this errs, should bubble up and quit app?
-                info!("Failed db insert: {}", err);
-                return Err(eyre::eyre!(err));
-            }
-        }
+            .set(user_status.eq(&show.user_status))
+            .execute(&mut self.conn)
+            .map(|_| ())
+            .wrap_err("could not update show in db")?;
+
+        info!("Updated row: {}", &show.imdb_id);
+        Ok(())
     }
 
-    info!("Inserted/Updated {} rows.", rows.len());
+    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
+    pub fn prefill_from_imdb(&mut self, rows: &Vec<TraktShow>) -> eyre::Result<()> {
+        info!("Filling db...");
 
-    Ok(())
+        use self::trakt_shows::dsl::*;
+
+        for row in rows {
+            diesel::insert_into(trakt_shows)
+                .values(row)
+                .on_conflict(imdb_id)
+                .do_update()
+                // update the values that might be updated in a new data dump
+                .set((
+                    release_year.eq(&row.release_year),
+                    no_seasons.eq(&row.no_seasons),
+                    no_episodes.eq(&row.no_episodes),
+                ))
+                .execute(&mut self.conn)
+                .map(|_| ())
+                .wrap_err("could not insert show")?;
+
+            info!("Inserted row: {}", &row.imdb_id);
+        }
+
+        info!("Inserted/Updated {} rows.", rows.len());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Blocking database queries were executed from `async fn`s, which is troublesome for the async runtime. Instead, they can be issued with tokio's `spawn_blocking`. A `Database` wrapper type makes this ergonomic. In fact, this obviates the need for `DataManager`'s thread; instead, we can rely on tokio's thread pool for blocking tasks.