### PR TITLE
Add `Database` trait and `PersistentDb` type with async logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,64 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,15 +756,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1442,9 +1375,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -1539,7 +1470,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "color-eyre",
- "crossbeam",
  "crossterm",
  "csv",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
 color-eyre = "0.6"
-crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 crossterm = "0.26.1"
 csv = "1.2.2"
 diesel = { version = "2.1.0", features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"] }
@@ -25,7 +24,7 @@ reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"
 simplelog = "0.12.1"
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "sync"] }
 tui-input = "0.7.1"
 
 [dependencies.ratatui]

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{TraktShow, UserStatusSeason, UserStatusShow, TraktSeason},
+    models::{TraktSeason, TraktShow, UserStatusSeason, UserStatusShow},
     sources::DataManager,
     trakt::{t_api, t_db},
 };
@@ -163,7 +163,7 @@ impl App {
             };
 
             // Update database
-            t_db::update_season(season)?;
+            t_db::Database::connect()?.update_season(season)?;
         }
 
         Ok(())
@@ -182,7 +182,7 @@ impl App {
             };
 
             // update db
-            t_db::update_show(show)?;
+            t_db::Database::connect()?.update_show(show)?;
         }
 
         Ok(())
@@ -205,10 +205,12 @@ impl App {
                         show.trakt_id = Some(show_details.ids.trakt as i32);
                         // let _ = t_db::update_show(show);
                     }
-                    let _ = t_db::update_show(&show);
+                    let mut db = t_db::Database::connect()?;
+
+                    let _ = db.update_show(&show)?;
 
                     // insert the seasons of a show
-                    self.show_view.seasons = t_db::update_show_with_seasons(show, &api_seasons)?;
+                    self.show_view.seasons = db.update_show_with_seasons(show, &api_seasons)?;
 
                     if !api_seasons.is_empty() {
                         self.show_view.season_table_state.select(Some(0));

--- a/src/interface/app.rs
+++ b/src/interface/app.rs
@@ -1,8 +1,8 @@
-use crate::{
-    models::{TraktSeason, TraktShow, UserStatusSeason, UserStatusShow},
-    sources::DataManager,
-    trakt::{t_api, t_db},
-};
+use crate::models::{TraktSeason, TraktShow, UserStatusSeason, UserStatusShow};
+use crate::sources::DataManager;
+use crate::trakt::t_api;
+use crate::trakt::t_db::{self, Database};
+
 use log::*;
 use ratatui::widgets::{ScrollbarState, TableState};
 use reqwest::Client;
@@ -51,7 +51,7 @@ pub struct App {
     pub client: Client,
 
     /// local cache of imdb + trakt data
-    pub cache: t_db::Database,
+    pub cache: t_db::PersistentDb,
 
     /// ui+handling changes based on the app's current view
     pub mode: AppMode,
@@ -78,7 +78,7 @@ impl App {
             data_manager,
 
             client: t_api::establish_http_client(),
-            cache: t_db::Database::connect().await?,
+            cache: t_db::PersistentDb::connect().await?,
 
             input: Input::default(),
             mode: AppMode::default(),
@@ -187,7 +187,7 @@ impl App {
             };
 
             // update db
-            t_db::Database::connect()
+            t_db::PersistentDb::connect()
                 .await?
                 .update_show(show.clone())
                 .await?;

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -55,7 +55,7 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Resu
                 app.mode = AppMode::Querying;
             }
             // cycle through watch status for a show
-            KeyCode::Char(' ') => app.toggle_watch_status()?,
+            KeyCode::Char(' ') => app.toggle_watch_status().await?,
 
             // open up tv show details view
             KeyCode::Char('l') | KeyCode::Right => {
@@ -81,7 +81,7 @@ pub async fn handle_key_events(key_event: KeyEvent, app: &mut App) -> eyre::Resu
             KeyCode::Left | KeyCode::Char('h') => app.mode = AppMode::MainView,
             KeyCode::Char('k') | KeyCode::Up => app.season_prev(1),
             KeyCode::Char('j') | KeyCode::Down => app.season_next(1),
-            KeyCode::Char(' ') => app.toggle_season_watch_status()?,
+            KeyCode::Char(' ') => app.toggle_season_watch_status().await?,
             _ => {}
         },
         _ => unimplemented!(),

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -28,7 +28,7 @@ use std::io;
 
 pub async fn run() -> eyre::Result<()> {
     // Create an application.
-    let app = App::new()?;
+    let app = App::new().await?;
 
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
@@ -58,7 +58,7 @@ async fn main_loop<B: ratatui::backend::Backend>(
         tui.draw(&mut app)?;
         // Handle events.
         match tui.events.next()? {
-            Event::Tick => app.tick()?,
+            Event::Tick => app.tick().await?,
             Event::Key(key_event) => handle_key_events(key_event, &mut app).await?,
             Event::Mouse(mouse_event) => handle_mouse_events(mouse_event, &mut app)?,
             Event::Resize(_, _) => {}

--- a/src/interface/ui.rs
+++ b/src/interface/ui.rs
@@ -4,8 +4,8 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{
-        Block, BorderType, Borders, Gauge, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-        Table, Wrap,
+        Block, BorderType, Borders, Gauge, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
+        Wrap,
     },
     Frame,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(let_chains)]
+#![feature(type_alias_impl_trait)]
 
 mod interface;
 mod models;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,5 +1,4 @@
 use crossbeam::channel::{Receiver, RecvError, Sender};
-use diesel::SqliteConnection;
 use log::*;
 
 use crate::models::TraktShow;
@@ -20,21 +19,21 @@ pub mod imdb_reader;
 /// Load all shows from imdb data dump and db.
 /// TODO: for now, assume that first startup fills all rows into db.
 /// Eventually, we may have to update this to update db on startup from a new data dump.
-fn load_combined_data_sources(ctx: &mut SqliteConnection) -> eyre::Result<Vec<TraktShow>> {
+fn load_combined_data_sources(db: &mut t_db::Database) -> eyre::Result<Vec<TraktShow>> {
     // load all shows, and fill db if db is empty
     // let items = imdb_reader::load_show_vec();
 
-    let row_count = t_db::count_trakt_db(ctx);
+    let row_count = db.count_shows();
     info!("row count: {}", row_count);
 
     if row_count < 100 {
         // if we dont have many rows in db (clean env or devel), load from imdb data
         let items = imdb_reader::load_show_vec();
         // TODO: put this on a thread, once i figure out borrowing?
-        t_db::prefill_db_from_imdb(ctx, &items).map(|()| items)
+        db.prefill_from_imdb(&items).map(|()| items)
     } else {
         // query everything from db
-        Ok(t_db::load_filtered_shows(ctx))
+        Ok(db.filtered_shows())
     }
 }
 
@@ -48,8 +47,8 @@ pub struct DataManager {
 
 impl DataManager {
     pub fn init() -> eyre::Result<DataManager> {
-        let mut ctx = t_db::establish_ctx();
-        let items = load_combined_data_sources(&mut ctx)?;
+        let mut db = t_db::Database::connect()?;
+        let items = load_combined_data_sources(&mut db)?;
         let (query_sender, query_receiver) = crossbeam::channel::unbounded();
         let (result_sender, result_receiver) = crossbeam::channel::unbounded();
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,7 +1,7 @@
 use log::*;
 
 use crate::models::TraktShow;
-use crate::trakt::t_db;
+use crate::trakt::t_db::{self, Database};
 
 pub mod imdb_reader;
 
@@ -18,7 +18,7 @@ pub mod imdb_reader;
 /// Load all shows from imdb data dump and db.
 /// TODO: for now, assume that first startup fills all rows into db.
 /// Eventually, we may have to update this to update db on startup from a new data dump.
-async fn load_combined_data_sources(db: &mut t_db::Database) -> eyre::Result<Vec<TraktShow>> {
+async fn load_combined_data_sources(db: &mut t_db::PersistentDb) -> eyre::Result<Vec<TraktShow>> {
     // load all shows, and fill db if db is empty
     // let items = imdb_reader::load_show_vec();
 
@@ -43,7 +43,7 @@ pub struct DataManager {
 
 impl DataManager {
     pub async fn init() -> eyre::Result<DataManager> {
-        let mut db = t_db::Database::connect().await?;
+        let mut db = t_db::PersistentDb::connect().await?;
         let items = load_combined_data_sources(&mut db).await?;
 
         Ok(DataManager { items })

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -2,87 +2,86 @@ use crate::models::{TraktSeason, TraktShow, UserStatusSeason, UserStatusShow};
 use crate::schema::{seasons, trakt_shows};
 use crate::trakt::t_api::ApiSeasonDetails;
 
-use chrono::prelude::*;
-use eyre::Context;
-use log::*;
 use std::env;
+use std::future::Future;
 use std::sync::Arc;
 
+use chrono::prelude::*;
 use diesel::prelude::*;
 use dotenvy::dotenv;
+use eyre::Context;
+use futures::FutureExt;
+use log::*;
+use tokio::sync::Mutex;
 
-/// A handle to the database of show data. Async methods for queries and updates
-/// are provided, synchronization happens internally.
-#[derive(Clone)]
-pub struct Database {
-    conn: Conn,
-}
+/// The cache database's interface. This is a trait to allow ease of testing.
+pub trait Database {
+    type Fut<T>: Future<Output = T>;
 
-type Conn = Arc<tokio::sync::Mutex<SqliteConnection>>;
+    /// Count shows stored in the database.
+    fn count_shows(&self) -> Self::Fut<usize>;
 
-impl std::fmt::Debug for Database {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Database { ... }")
-    }
-}
+    /// Get all shows that are unwatched and are released.
+    fn filtered_shows(&self) -> Self::Fut<Vec<TraktShow>>;
 
-impl Database {
-    pub fn connect_sync() -> eyre::Result<Database> {
-        dotenv().ok();
+    /// Update the database status of a show.
+    fn update_show(&self, show: TraktShow) -> Self::Fut<eyre::Result<()>>;
 
-        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
-        Ok(Database {
-            conn: Arc::new(tokio::sync::Mutex::new(SqliteConnection::establish(
-                &database_url,
-            )?)),
-        })
-    }
+    fn update_season(&self, season: TraktSeason) -> Self::Fut<eyre::Result<()>>;
 
-    pub async fn connect() -> eyre::Result<Database> {
-        tokio::task::spawn_blocking(Self::connect_sync)
-            .await
-            .unwrap()
-    }
-
-    /// count the rows in the db
-    /// (this should be fast - am i doing this inefficiently?)
-    pub async fn count_shows(&self) -> usize {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || Self::count_shows_impl(conn))
-            .await
-            .unwrap()
-    }
-
-    /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
-    pub async fn filtered_shows(&self) -> Vec<TraktShow> {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || Self::filtered_shows_impl(conn))
-            .await
-            .unwrap()
-    }
-
-    /// update the status of a show **in the DB**
-    pub async fn update_show(&self, show: TraktShow) -> eyre::Result<()> {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || Self::update_show_impl(conn, &show))
-            .await
-            .unwrap()
-    }
-
-    pub async fn update_season(&self, season: TraktSeason) -> eyre::Result<()> {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || Self::update_season_impl(conn, &season))
-            .await
-            .unwrap()
-    }
-
-    pub async fn update_show_with_seasons(
+    fn update_show_with_seasons(
         &self,
         show: &TraktShow,
         api_seasons: &[ApiSeasonDetails],
-    ) -> eyre::Result<Vec<TraktSeason>> {
-        let conn = self.conn.clone();
+    ) -> Self::Fut<eyre::Result<Vec<TraktSeason>>>;
 
+    /// Fill database with shows loaded from the IMDB dump.
+    fn prefill_from_imdb(&self, rows: Vec<TraktShow>) -> Self::Fut<eyre::Result<()>>;
+}
+
+/// Handle to sqlite-backed persistent database. Provides an async interface
+/// with synchronization handled inside.
+#[derive(Clone)]
+pub struct PersistentDb {
+    conn: Conn,
+}
+
+type Conn = Arc<Mutex<SqliteConnection>>;
+
+impl std::fmt::Debug for PersistentDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("PersistentDb { ... }")
+    }
+}
+
+// Name the anonymous future (with unstable type_alias_impl_trait feature) so it
+// may be referenced in a trait impl.
+pub type PersistentDbFuture<T> = impl Future<Output = T>;
+
+impl Database for PersistentDb {
+    type Fut<T> = PersistentDbFuture<T>;
+
+    fn count_shows(&self) -> Self::Fut<usize> {
+        self.on_blocking_task(Self::count_shows_impl)
+    }
+
+    fn filtered_shows(&self) -> PersistentDbFuture<Vec<TraktShow>> {
+        self.on_blocking_task(Self::filtered_shows_impl)
+    }
+
+    fn update_show(&self, show: TraktShow) -> PersistentDbFuture<eyre::Result<()>> {
+        self.on_blocking_task(move |conn| Self::update_show_impl(conn, &show))
+    }
+
+    fn update_season(&self, season: TraktSeason) -> Self::Fut<eyre::Result<()>> {
+        self.on_blocking_task(move |conn| Self::update_season_impl(conn, &season))
+    }
+
+    fn update_show_with_seasons(
+        &self,
+        show: &TraktShow,
+        api_seasons: &[ApiSeasonDetails],
+    ) -> Self::Fut<eyre::Result<Vec<TraktSeason>>> {
         let trakt_seasons: Vec<_> = api_seasons
             .iter()
             .map(|s| TraktSeason {
@@ -96,50 +95,65 @@ impl Database {
             })
             .collect();
 
-        tokio::task::spawn_blocking(move || {
-            Self::update_show_with_seasons_impl(conn, trakt_seasons)
-        })
-        .await
-        .unwrap()
+        self.on_blocking_task(move |conn| Self::update_show_with_seasons_impl(conn, trakt_seasons))
     }
 
-    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-    pub async fn prefill_from_imdb(&self, rows: Vec<TraktShow>) -> eyre::Result<()> {
-        let conn = self.conn.clone();
-        tokio::task::spawn_blocking(move || Self::prefill_from_imdb_impl(conn, &rows))
+    fn prefill_from_imdb(&self, rows: Vec<TraktShow>) -> PersistentDbFuture<eyre::Result<()>> {
+        self.on_blocking_task(move |conn| Self::prefill_from_imdb_impl(conn, &rows))
+    }
+}
+
+impl PersistentDb {
+    pub fn connect_sync() -> eyre::Result<PersistentDb> {
+        dotenv().ok();
+
+        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
+        Ok(PersistentDb {
+            conn: Arc::new(Mutex::new(SqliteConnection::establish(&database_url)?)),
+        })
+    }
+
+    pub async fn connect() -> eyre::Result<PersistentDb> {
+        tokio::task::spawn_blocking(Self::connect_sync)
             .await
             .unwrap()
     }
 
-    fn count_shows_impl(conn: Conn) -> usize {
-        use self::trakt_shows::dsl::*;
-
-        let mut conn = conn.blocking_lock();
-        let rows = trakt_shows
-            .select(TraktShow::as_select())
-            .load_iter(&mut *conn)
-            .unwrap();
-
-        rows.into_iter().count()
+    fn on_blocking_task<T, F>(&self, f: F) -> PersistentDbFuture<T>
+    where
+        F: 'static + Send + FnOnce(&mut SqliteConnection) -> T,
+        T: 'static + Send,
+    {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = conn.blocking_lock();
+            f(&mut *conn)
+        })
+        .map(Result::unwrap)
     }
 
-    fn filtered_shows_impl(conn: Conn) -> Vec<TraktShow> {
+    fn count_shows_impl(conn: &mut SqliteConnection) -> usize {
+        use self::trakt_shows::dsl::*;
+
+        let rows: i64 = trakt_shows.count().get_result(conn).unwrap();
+        rows.try_into().unwrap()
+    }
+
+    fn filtered_shows_impl(conn: &mut SqliteConnection) -> Vec<TraktShow> {
         let cap_year = Utc::now().year() + 1;
 
-        let mut conn = conn.blocking_lock();
         trakt_shows::table
             .order_by(trakt_shows::release_year)
             .filter(trakt_shows::release_year.le(cap_year))
             .filter(trakt_shows::user_status.ne(UserStatusShow::Unwatched))
             .select(TraktShow::as_returning())
-            .load(&mut *conn)
+            .load(conn)
             .unwrap()
     }
 
-    fn update_show_impl(conn: Conn, show: &TraktShow) -> eyre::Result<()> {
+    fn update_show_impl(conn: &mut SqliteConnection, show: &TraktShow) -> eyre::Result<()> {
         use self::trakt_shows::dsl::*;
 
-        let mut conn = conn.blocking_lock();
         diesel::insert_into(trakt_shows)
             .values(show)
             .on_conflict(imdb_id)
@@ -149,7 +163,7 @@ impl Database {
                 user_status.eq(&show.user_status),
                 overview.eq(&overview),
             ))
-            .execute(&mut *conn)
+            .execute(conn)
             .map(|_| ())
             .wrap_err("could not update show in db")?;
 
@@ -157,17 +171,19 @@ impl Database {
         Ok(())
     }
 
-    pub fn update_season_impl(conn: Conn, season: &TraktSeason) -> eyre::Result<()> {
+    pub fn update_season_impl(
+        conn: &mut SqliteConnection,
+        season: &TraktSeason,
+    ) -> eyre::Result<()> {
         use self::seasons::dsl::*;
 
-        let mut conn = conn.blocking_lock();
         let updated_season: TraktSeason = diesel::update(seasons.filter(id.eq(season.id)))
             .set((
                 season_number.eq(&season.season_number),
                 episode_count.eq(&season.episode_count),
                 user_status.eq(&season.user_status),
             ))
-            .get_result(&mut *conn)?;
+            .get_result(conn)?;
 
         info!("Updated to season: {:?}", updated_season);
 
@@ -178,26 +194,28 @@ impl Database {
     }
 
     fn update_show_with_seasons_impl(
-        conn: Conn,
+        conn: &mut SqliteConnection,
         trakt_seasons: Vec<TraktSeason>,
     ) -> eyre::Result<Vec<TraktSeason>> {
         use self::seasons::dsl::*;
 
-        let mut conn = conn.blocking_lock();
         for season in trakt_seasons.iter() {
             diesel::insert_into(seasons)
                 .values(season)
                 .on_conflict(id)
                 .do_update()
                 .set(season_number.eq(season.season_number))
-                .execute(&mut *conn)
+                .execute(conn)
                 .wrap_err("failed db insert")?;
         }
 
         Ok(trakt_seasons)
     }
 
-    fn prefill_from_imdb_impl(conn: Conn, rows: &Vec<TraktShow>) -> eyre::Result<()> {
+    fn prefill_from_imdb_impl(
+        conn: &mut SqliteConnection,
+        rows: &Vec<TraktShow>,
+    ) -> eyre::Result<()> {
         info!("Filling db...");
 
         use self::trakt_shows::dsl::*;
@@ -213,7 +231,7 @@ impl Database {
                     no_seasons.eq(&row.no_seasons),
                     no_episodes.eq(&row.no_episodes),
                 ))
-                .execute(&mut *conn.blocking_lock())
+                .execute(conn)
                 .map(|_| ())
                 .wrap_err("could not insert show")?;
 

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -1,180 +1,155 @@
 use crate::models::{TraktSeason, TraktShow, UserStatusSeason, UserStatusShow};
 use crate::schema::{seasons, trakt_shows};
+use crate::trakt::t_api::ApiSeasonDetails;
 
 use chrono::prelude::*;
+use eyre::Context;
 use log::*;
 use std::env;
 
 use diesel::prelude::*;
 use dotenvy::dotenv;
 
-use super::t_api::ApiSeasonDetails;
-
-pub fn establish_ctx() -> SqliteConnection {
-    dotenv().ok();
-
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
-    SqliteConnection::establish(&database_url).unwrap_or_else(|err| {
-        info!("{}", err);
-        panic!();
-    })
+pub struct Database {
+    conn: SqliteConnection,
 }
 
-/// count the rows in the db
-/// (this should be fast - am i doing this inefficiently?)
-pub fn count_trakt_db(ctx: &mut SqliteConnection) -> usize {
-    use self::trakt_shows::dsl::*;
+impl Database {
+    pub fn connect() -> eyre::Result<Database> {
+        dotenv().ok();
 
-    let rows = trakt_shows
-        .select(TraktShow::as_select())
-        .load_iter(ctx)
-        .unwrap();
-
-    rows.into_iter().count()
-}
-
-/// Return all rows in the db that are not marked as unwatched, and don't have release in the future
-pub fn load_filtered_shows(ctx: &mut SqliteConnection) -> Vec<TraktShow> {
-    let cap_year = Utc::now().year() + 1;
-
-    trakt_shows::table
-        .order_by(trakt_shows::release_year)
-        .filter(trakt_shows::release_year.le(cap_year))
-        .filter(trakt_shows::user_status.ne(UserStatusShow::Unwatched))
-        .select(TraktShow::as_returning())
-        .load(ctx)
-        .unwrap()
-}
-
-/// update the status of a show **in the DB**
-pub fn update_show(show: &TraktShow) -> eyre::Result<()> {
-    use self::trakt_shows::dsl::*;
-
-    let mut ctx = establish_ctx();
-
-    match diesel::insert_into(trakt_shows)
-        .values(show)
-        .on_conflict(imdb_id)
-        .do_update()
-        .set((
-            trakt_id.eq(&show.trakt_id),
-            user_status.eq(&show.user_status),
-            overview.eq(&show.overview),
-        ))
-        .execute(&mut ctx)
-    {
-        Ok(_) => {
-            info!("Updated row: {}", &show.imdb_id);
-            Ok(())
-        }
-        Err(err) => {
-            info!("panik on update: {}", err);
-            Err(eyre::eyre!(err))
-        }
-    }
-}
-
-/// update each(?) episode of a season, and the season entry in the db
-pub fn update_season(season: &TraktSeason) -> eyre::Result<()> {
-    use self::seasons::dsl::*;
-
-    let mut ctx = establish_ctx();
-
-    let updated_season = diesel::update(seasons.filter(id.eq(season.id)))
-        .set((
-            // update any rows likely to change
-            season_number.eq(&season.season_number),
-            episode_count.eq(&season.episode_count),
-            user_status.eq(&season.user_status),
-        ))
-        .get_result::<TraktSeason>(&mut ctx);
-
-    info!("Updated to season: {:?}", updated_season);
-
-    // TODO: update the episodes in this season, if necessary
-    // (if user selects ON_RELEASE for this season)
-
-    Ok(())
-}
-
-/// Update a show with details and seasons
-pub fn update_show_with_seasons(show: &TraktShow, api_seasons: &[ApiSeasonDetails]) -> eyre::Result<Vec<TraktSeason>> {
-    use self::seasons::dsl::*;
-
-    let mut ctx = establish_ctx();
-
-    let mut trakt_seasons = vec![];
-
-    info!("Updating seasons...");
-
-    for season in api_seasons {
-        let trakt_season = TraktSeason {
-            id: season.ids.trakt as i32,
-            title: season.title.clone(),
-            first_aired: Some(season.first_aired.naive_utc()),
-            show_id: show.trakt_id.unwrap() as i32,
-            season_number: season.number as i32,
-            episode_count: season.episode_count as i32,
-            user_status: UserStatusSeason::Unfilled,
-        };
-
-        match diesel::insert_into(seasons)
-            .values(trakt_season.clone())
-            .on_conflict(id)
-            .do_update()
-            .set((season_number.eq(trakt_season.season_number),))
-            .execute(&mut ctx)
-        {
-            Ok(_) => {
-                info!(
-                    "Updated show season: {} {}",
-                    &show.imdb_id, &season.ids.trakt
-                );
-
-                trakt_seasons.push(trakt_season);
-            }
-            Err(err) => {
-                error!("Failed db insert {}", err);
-                return Err(eyre::eyre!(err));
-            }
-        }
+        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
+        Ok(Database {
+            conn: SqliteConnection::establish(&database_url)?,
+        })
     }
 
-    Ok(trakt_seasons)
-}
+    /// count the rows in the db
+    /// (this should be fast - am i doing this inefficiently?)
+    pub fn count_shows(&mut self) -> usize {
+        use self::trakt_shows::dsl::*;
 
-/// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-pub fn prefill_db_from_imdb(ctx: &mut SqliteConnection, rows: &Vec<TraktShow>) -> eyre::Result<()> {
-    info!("Filling db...");
+        let rows = trakt_shows
+            .select(TraktShow::as_select())
+            .load_iter(&mut self.conn)
+            .unwrap();
 
-    use self::trakt_shows::dsl::*;
+        rows.into_iter().count()
+    }
 
-    for row in rows {
-        match diesel::insert_into(trakt_shows)
-            .values(row)
+    /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
+    pub fn filtered_shows(&mut self) -> Vec<TraktShow> {
+        let cap_year = Utc::now().year() + 1;
+
+        trakt_shows::table
+            .order_by(trakt_shows::release_year)
+            .filter(trakt_shows::release_year.le(cap_year))
+            .filter(trakt_shows::user_status.ne(UserStatusShow::Unwatched))
+            .select(TraktShow::as_returning())
+            .load(&mut self.conn)
+            .unwrap()
+    }
+
+    /// update the status of a show **in the DB**
+    pub fn update_show(&mut self, show: &TraktShow) -> eyre::Result<()> {
+        use self::trakt_shows::dsl::*;
+
+        diesel::insert_into(trakt_shows)
+            .values(show)
             .on_conflict(imdb_id)
             .do_update()
-            // update the values that might be updated in a new data dump
             .set((
-                release_year.eq(&row.release_year),
-                no_seasons.eq(&row.no_seasons),
-                no_episodes.eq(&row.no_episodes),
+                trakt_id.eq(&show.trakt_id),
+                user_status.eq(&show.user_status),
+                overview.eq(&overview),
             ))
-            .execute(ctx)
-        {
-            Ok(_c) => {
-                // can i count only which rows were updated?
-                info!("Inserted row: {}", &row.imdb_id);
-            }
-            Err(err) => {
-                // TODO: if this errs, should bubble up and quit app?
-                info!("Failed db insert: {}", err);
-                return Err(eyre::eyre!(err));
-            }
-        }
+            .execute(&mut self.conn)
+            .map(|_| ())
+            .wrap_err("could not update show in db")?;
+
+        info!("Updated row: {}", &show.imdb_id);
+        Ok(())
     }
 
-    info!("Inserted/Updated {} rows.", rows.len());
+    pub fn update_season(&mut self, season: &TraktSeason) -> eyre::Result<()> {
+        use self::seasons::dsl::*;
 
-    Ok(())
+        let updated_season: TraktSeason = diesel::update(seasons.filter(id.eq(season.id)))
+            .set((
+                season_number.eq(&season.season_number),
+                episode_count.eq(&season.episode_count),
+                user_status.eq(&season.user_status),
+            ))
+            .get_result(&mut self.conn)?;
+
+        info!("Updated to season: {:?}", updated_season);
+
+        // TODO: update the episodes in this season, if necessary
+        // (if user selects ON_RELEASE for this season)
+
+        Ok(())
+    }
+
+    pub fn update_show_with_seasons(
+        &mut self,
+        show: &TraktShow,
+        api_seasons: &[ApiSeasonDetails],
+    ) -> eyre::Result<Vec<TraktSeason>> {
+        use self::seasons::dsl::*;
+
+        let trakt_seasons: Vec<_> = api_seasons
+            .iter()
+            .map(|s| TraktSeason {
+                id: s.ids.trakt as i32,
+                title: s.title.clone(),
+                first_aired: Some(s.first_aired.naive_utc()),
+                show_id: show.trakt_id.unwrap() as i32,
+                season_number: s.number as i32,
+                episode_count: s.episode_count as i32,
+                user_status: UserStatusSeason::Unfilled,
+            })
+            .collect();
+
+        for season in trakt_seasons.iter() {
+            diesel::insert_into(seasons)
+                .values(season)
+                .on_conflict(id)
+                .do_update()
+                .set(season_number.eq(season.season_number))
+                .execute(&mut self.conn)
+                .wrap_err("failed db insert")?;
+            info!("Updated show season: {} {}", show.imdb_id, season.id);
+        }
+
+        Ok(trakt_seasons)
+    }
+
+    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
+    pub fn prefill_from_imdb(&mut self, rows: &Vec<TraktShow>) -> eyre::Result<()> {
+        info!("Filling db...");
+
+        use self::trakt_shows::dsl::*;
+
+        for row in rows {
+            diesel::insert_into(trakt_shows)
+                .values(row)
+                .on_conflict(imdb_id)
+                .do_update()
+                // update the values that might be updated in a new data dump
+                .set((
+                    release_year.eq(&row.release_year),
+                    no_seasons.eq(&row.no_seasons),
+                    no_episodes.eq(&row.no_episodes),
+                ))
+                .execute(&mut self.conn)
+                .map(|_| ())
+                .wrap_err("could not insert show")?;
+
+            info!("Inserted row: {}", &row.imdb_id);
+        }
+
+        info!("Inserted/Updated {} rows.", rows.len());
+
+        Ok(())
+    }
 }

--- a/src/trakt/t_db.rs
+++ b/src/trakt/t_db.rs
@@ -6,96 +6,82 @@ use chrono::prelude::*;
 use eyre::Context;
 use log::*;
 use std::env;
+use std::sync::Arc;
 
 use diesel::prelude::*;
 use dotenvy::dotenv;
 
+/// A handle to the database of show data. Async methods for queries and updates
+/// are provided, synchronization happens internally.
+#[derive(Clone)]
 pub struct Database {
-    conn: SqliteConnection,
+    conn: Conn,
+}
+
+type Conn = Arc<tokio::sync::Mutex<SqliteConnection>>;
+
+impl std::fmt::Debug for Database {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Database { ... }")
+    }
 }
 
 impl Database {
-    pub fn connect() -> eyre::Result<Database> {
+    pub fn connect_sync() -> eyre::Result<Database> {
         dotenv().ok();
 
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
         Ok(Database {
-            conn: SqliteConnection::establish(&database_url)?,
+            conn: Arc::new(tokio::sync::Mutex::new(SqliteConnection::establish(
+                &database_url,
+            )?)),
         })
+    }
+
+    pub async fn connect() -> eyre::Result<Database> {
+        tokio::task::spawn_blocking(Self::connect_sync)
+            .await
+            .unwrap()
     }
 
     /// count the rows in the db
     /// (this should be fast - am i doing this inefficiently?)
-    pub fn count_shows(&mut self) -> usize {
-        use self::trakt_shows::dsl::*;
-
-        let rows = trakt_shows
-            .select(TraktShow::as_select())
-            .load_iter(&mut self.conn)
-            .unwrap();
-
-        rows.into_iter().count()
+    pub async fn count_shows(&self) -> usize {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::count_shows_impl(conn))
+            .await
+            .unwrap()
     }
 
     /// Return all rows in the db that are not marked as unwatched, and don't have release in the future
-    pub fn filtered_shows(&mut self) -> Vec<TraktShow> {
-        let cap_year = Utc::now().year() + 1;
-
-        trakt_shows::table
-            .order_by(trakt_shows::release_year)
-            .filter(trakt_shows::release_year.le(cap_year))
-            .filter(trakt_shows::user_status.ne(UserStatusShow::Unwatched))
-            .select(TraktShow::as_returning())
-            .load(&mut self.conn)
+    pub async fn filtered_shows(&self) -> Vec<TraktShow> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::filtered_shows_impl(conn))
+            .await
             .unwrap()
     }
 
     /// update the status of a show **in the DB**
-    pub fn update_show(&mut self, show: &TraktShow) -> eyre::Result<()> {
-        use self::trakt_shows::dsl::*;
-
-        diesel::insert_into(trakt_shows)
-            .values(show)
-            .on_conflict(imdb_id)
-            .do_update()
-            .set((
-                trakt_id.eq(&show.trakt_id),
-                user_status.eq(&show.user_status),
-                overview.eq(&overview),
-            ))
-            .execute(&mut self.conn)
-            .map(|_| ())
-            .wrap_err("could not update show in db")?;
-
-        info!("Updated row: {}", &show.imdb_id);
-        Ok(())
+    pub async fn update_show(&self, show: TraktShow) -> eyre::Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::update_show_impl(conn, &show))
+            .await
+            .unwrap()
     }
 
-    pub fn update_season(&mut self, season: &TraktSeason) -> eyre::Result<()> {
-        use self::seasons::dsl::*;
-
-        let updated_season: TraktSeason = diesel::update(seasons.filter(id.eq(season.id)))
-            .set((
-                season_number.eq(&season.season_number),
-                episode_count.eq(&season.episode_count),
-                user_status.eq(&season.user_status),
-            ))
-            .get_result(&mut self.conn)?;
-
-        info!("Updated to season: {:?}", updated_season);
-
-        // TODO: update the episodes in this season, if necessary
-        // (if user selects ON_RELEASE for this season)
-
-        Ok(())
+    pub async fn update_season(&self, season: TraktSeason) -> eyre::Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::update_season_impl(conn, &season))
+            .await
+            .unwrap()
     }
 
-    pub fn update_show_with_seasons(
-        &mut self,
+    pub async fn update_show_with_seasons(
+        &self,
         show: &TraktShow,
         api_seasons: &[ApiSeasonDetails],
     ) -> eyre::Result<Vec<TraktSeason>> {
-        use self::seasons::dsl::*;
+        let conn = self.conn.clone();
 
         let trakt_seasons: Vec<_> = api_seasons
             .iter()
@@ -110,22 +96,108 @@ impl Database {
             })
             .collect();
 
+        tokio::task::spawn_blocking(move || {
+            Self::update_show_with_seasons_impl(conn, trakt_seasons)
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
+    pub async fn prefill_from_imdb(&self, rows: Vec<TraktShow>) -> eyre::Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || Self::prefill_from_imdb_impl(conn, &rows))
+            .await
+            .unwrap()
+    }
+
+    fn count_shows_impl(conn: Conn) -> usize {
+        use self::trakt_shows::dsl::*;
+
+        let mut conn = conn.blocking_lock();
+        let rows = trakt_shows
+            .select(TraktShow::as_select())
+            .load_iter(&mut *conn)
+            .unwrap();
+
+        rows.into_iter().count()
+    }
+
+    fn filtered_shows_impl(conn: Conn) -> Vec<TraktShow> {
+        let cap_year = Utc::now().year() + 1;
+
+        let mut conn = conn.blocking_lock();
+        trakt_shows::table
+            .order_by(trakt_shows::release_year)
+            .filter(trakt_shows::release_year.le(cap_year))
+            .filter(trakt_shows::user_status.ne(UserStatusShow::Unwatched))
+            .select(TraktShow::as_returning())
+            .load(&mut *conn)
+            .unwrap()
+    }
+
+    fn update_show_impl(conn: Conn, show: &TraktShow) -> eyre::Result<()> {
+        use self::trakt_shows::dsl::*;
+
+        let mut conn = conn.blocking_lock();
+        diesel::insert_into(trakt_shows)
+            .values(show)
+            .on_conflict(imdb_id)
+            .do_update()
+            .set((
+                trakt_id.eq(&show.trakt_id),
+                user_status.eq(&show.user_status),
+                overview.eq(&overview),
+            ))
+            .execute(&mut *conn)
+            .map(|_| ())
+            .wrap_err("could not update show in db")?;
+
+        info!("Updated row: {}", &show.imdb_id);
+        Ok(())
+    }
+
+    pub fn update_season_impl(conn: Conn, season: &TraktSeason) -> eyre::Result<()> {
+        use self::seasons::dsl::*;
+
+        let mut conn = conn.blocking_lock();
+        let updated_season: TraktSeason = diesel::update(seasons.filter(id.eq(season.id)))
+            .set((
+                season_number.eq(&season.season_number),
+                episode_count.eq(&season.episode_count),
+                user_status.eq(&season.user_status),
+            ))
+            .get_result(&mut *conn)?;
+
+        info!("Updated to season: {:?}", updated_season);
+
+        // TODO: update the episodes in this season, if necessary
+        // (if user selects ON_RELEASE for this season)
+
+        Ok(())
+    }
+
+    fn update_show_with_seasons_impl(
+        conn: Conn,
+        trakt_seasons: Vec<TraktSeason>,
+    ) -> eyre::Result<Vec<TraktSeason>> {
+        use self::seasons::dsl::*;
+
+        let mut conn = conn.blocking_lock();
         for season in trakt_seasons.iter() {
             diesel::insert_into(seasons)
                 .values(season)
                 .on_conflict(id)
                 .do_update()
                 .set(season_number.eq(season.season_number))
-                .execute(&mut self.conn)
+                .execute(&mut *conn)
                 .wrap_err("failed db insert")?;
-            info!("Updated show season: {} {}", show.imdb_id, season.id);
         }
 
         Ok(trakt_seasons)
     }
 
-    /// Overwrites (or fills) db with the rows parsed from an IMDB data dump.
-    pub fn prefill_from_imdb(&mut self, rows: &Vec<TraktShow>) -> eyre::Result<()> {
+    fn prefill_from_imdb_impl(conn: Conn, rows: &Vec<TraktShow>) -> eyre::Result<()> {
         info!("Filling db...");
 
         use self::trakt_shows::dsl::*;
@@ -141,7 +213,7 @@ impl Database {
                     no_seasons.eq(&row.no_seasons),
                     no_episodes.eq(&row.no_episodes),
                 ))
-                .execute(&mut self.conn)
+                .execute(&mut *conn.blocking_lock())
                 .map(|_| ())
                 .wrap_err("could not insert show")?;
 


### PR DESCRIPTION
`PersistentDb` wraps the database connection and provides asynchronous methods for querying the database (synchronization is handled internally). Other code that accessed the DB from async callstacks were fixed.

`Database` is a trait representing the API the database provides. While not added yet, this enables unit testing code that would otherwise need to access the database. 